### PR TITLE
Added prometheus to deployment so that can be accessed by azure

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure('2') do |config|
     azure.resource_group_name = "devops-minitwit-S"
     azure.vm_name = "minitwitb"
     azure.dns_name = "minitwitb"
-    azure.tcp_endpoints = [3000, 9000, 8080]
+    azure.tcp_endpoints = [3000, 9000, 8080, 3001, 9090]
   end
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,26 @@ services:
       - isolated-network
     volumes: 
       - /mongodata:/data/db
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - isolated-network
+    depends_on:
+      - spring
+  grafana:
+    image: grafana/grafana:4.5.2
+    ports:
+      - "3001:3001"
+    networks:
+      - isolated-network
+    depends_on:
+      - spring
+      - prometheus
 networks:
   isolated-network:
     driver: bridge

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,22 @@
+
+
+# Sample Prometheus config
+# This assumes that your Prometheus instance can access this application on localhost:8080
+
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+  external_labels:
+    monitor: 'codelab-monitor'
+rule_files:
+  - 'prometheus.rules.yml'
+scrape_configs:
+  - job_name: 'spring-backend'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['spring:8080']
+        
+
+


### PR DESCRIPTION
This branch is adding prometheus to the deployment, first I fixed prometheus on backend only for testing, but that would not be accessed by azure meaning only for running the backend in browser without the docker image. So I pushed prometheus dependencies on backend and I believe that if we run the docker-compose in deployment then it will run prometheus and grafana image. After that will read the prometheus .yml file that tells the address for which should read the data, the rule says by putting the backend image name then the port will be enough for promethes find the address to the spring.

I am not sure if I should have added the ports on vagrantfile